### PR TITLE
Build fixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.20.0",
+    "bootstrap": "^4.5.2",
     "classnames": "^2.2.6",
     "jwt-decode": "^2.2.0",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "client": "npm start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "build": "cd client && npm run build",
-    "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm run client-install && npm run build && npm run server-install",
+    "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm install && npm run client-install && npm run build && npm run server-install",
     "start": "node backend/server.js"
   },
   "eslintConfig": {


### PR DESCRIPTION
Added bootstrap as dependency.
Added top level `npm install` to heroku build script

This has fixed the issue with the build failing. I just had to change the heroku-postbuild script to run `npm install` at the root of the project as well as within `/client` and `/backend`