### PR TITLE
fixed horizontal alignment on scrollable pages

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,3 +1,8 @@
+html {
+  overflow-x: hidden;
+  margin-right: calc(-1 * (100vw - 100%));
+}
+
 .error-text {
   color: red;
   font-size: small;


### PR DESCRIPTION
Currently on master, scrollable pages (pages that take up more than the height of the screen) do not have the same horizontal alignment as unscrollable pages, which is very obvious when navigating between such pages as the navbar shifts slightly left/right. Not good.

The issue here is the presence of the scrollbar, which the browser does not view as an overlay, but rather as an area that cannot be used for rendering.

The fix is fairly subtle and is absolutely not something I knew how to do myself. You need to add a negative margin-right on the entire html element with negative size 100vw-100%. 100vw represents the width of the _viewport_, which includes the scrollbar. 100% represents the width of the renderable area, so the difference is the scroll bar.

I'm told this might not work on sufficiently early version of internet explorer, but I don't take users of such software seriously as people.